### PR TITLE
github: workflows: add mayhem for API workflow

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,0 +1,52 @@
+name: 'Mayhem for API'
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-go@v2
+      with:
+        go-version: "1.17.6"
+
+    - run: |
+        GO_BUILD_FLAGS='-v -mod=readonly' ./build.sh
+        ./bin/etcd -name etcd0 &
+
+    # Run Mayhem for API
+    - name: Run Mayhem for API
+      uses: ForAllSecure/mapi-action@v1
+      continue-on-error: true
+      with:
+        mapi-token: ${{ secrets.MAPI_TOKEN }}
+        api-url: http://localhost:2379/
+        api-spec: Documentation/dev-guide/apispec/swagger/rpc.swagger.json
+        target: makesoftwaresafe/etcd
+        duration: 1min
+        sarif-report: mapi.sarif
+        html-report: mapi.html
+        run-args: |
+          --ignore-rule
+          AuthenticationBypass
+          --ignore-endpoint
+          POST v3/lease/revoke
+          --ignore-endpoint
+          POST v3/watch
+          --ignore-endpoint
+          POST v3/cluster/member
+
+    # Archive HTML report
+    - name: Archive Mayhem for API report
+      uses: actions/upload-artifact@v2
+      with:
+        name: mapi-report
+        path: mapi.html
+
+    # Upload SARIF file (only available on public repos or github enterprise)
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: mapi.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Tests](https://github.com/etcd-io/etcd/actions/workflows/tests.yaml/badge.svg)](https://github.com/etcd-io/etcd/actions/workflows/tests.yaml)
 [![asset-transparency](https://github.com/etcd-io/etcd/actions/workflows/asset-transparency.yaml/badge.svg)](https://github.com/etcd-io/etcd/actions/workflows/asset-transparency.yaml)
 [![codeql-analysis](https://github.com/etcd-io/etcd/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/etcd-io/etcd/actions/workflows/codeql-analysis.yml)
+[![Mayhem for API](https://mayhem4api.forallsecure.com/api/v1/api-target/makesoftwaresafe/etcd/badge/icon.svg)](https://mayhem4api.forallsecure.com/makesoftwaresafe/etcd/latest-job?scm_branch=main)
 [![Docs](https://img.shields.io/badge/docs-latest-green.svg)](https://etcd.io/docs)
 [![Godoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/etcd-io/etcd)
 [![Releases](https://img.shields.io/github/release/etcd-io/etcd/all.svg?style=flat-square)](https://github.com/etcd-io/etcd/releases)


### PR DESCRIPTION
Now that mayhem for API has a [free plan](https://forallsecure.com/plans), I thought etcd might want to try it out. This is the API fuzzer that found https://github.com/etcd-io/etcd/pull/13084 and https://github.com/etcd-io/etcd/pull/13086.

Mayhem for API docs: https://mayhem4api.forallsecure.com/docs/
mapi GitHub action docs: https://github.com/marketplace/actions/mayhem-for-api

Merging new workflows across forks is a bit weird. You can see some results in my fork:
 * the action: https://github.com/makesoftwaresafe/etcd/actions/runs/1820455555
 * the scan results: https://github.com/makesoftwaresafe/etcd/pull/1/checks?check_run_id=5132126328
 * the details in the mayhem for API ui: https://mayhem4api.forallsecure.com/job/10656

If you're interested, this will still take a bit of out-of-PR effort to integrate:
 * sign up for mapi, creating an etcd-io organization
 * create a mapi service account within the etcd-io organization
 * modify the mapi.yaml action in this PR to point at your mapi organization
 * add the service account's API token to github as a repository secret named MAPI_TOKEN

Happy to help as much as needed! :)